### PR TITLE
BugFix for download_attachment_base64 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ expect(email.attachments.size).to be(1)
 
 # download the attachment as base64 (easier than byte arrays for ruby client)
 email_controller = MailSlurpClient::EmailControllerApi.new
-downloaded_attachment = email_controller.download_attachment_base64(email.attachments[0], email.id)
+downloaded_attachment = email_controller.download_attachment_base64(email.id, email.attachments[0])
 
 # extract attachment content
 expect(downloaded_attachment.content_type).to eq("text/plain")


### PR DESCRIPTION
The parameters for `email_controller.download_attachment_base64` are wrongly documented in the README. They need to be swapped. Otherwise the call responds with an 400 error.